### PR TITLE
Tweak op calculation.

### DIFF
--- a/test_regress/t/t_const_opt_red.pl
+++ b/test_regress/t/t_const_opt_red.pl
@@ -19,7 +19,7 @@ execute(
     );
 
 if ($Self->{vlt}) {
-    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 149);
+    file_grep($Self->{stats}, qr/Optimizations, Const bit op reduction\s+(\d+)/i, 155);
 }
 
 ok(1);


### PR DESCRIPTION
I think your https://github.com/verilator/verilator/pull/3097 is correct.
I want to And(1, resultp) should be counted to expOps.

While thinking about golden change, I also found incorrect expOps calculation that has been there from beginning.